### PR TITLE
use core_layout_block_create_after in order to have order's count in csv

### DIFF
--- a/app/code/community/Quafzi/CustomerGridOrderCount/etc/config.xml
+++ b/app/code/community/Quafzi/CustomerGridOrderCount/etc/config.xml
@@ -23,14 +23,14 @@
             </modules>
         </translate>
         <events>
-            <adminhtml_block_html_before>
+            <core_layout_block_create_after>
                 <observers>
                     <quafzi_customergridordercount_adminhtml_block_html_before>
                         <class>quafzi_customergridordercount/observer</class>
                         <method>beforeBlockToHtml</method>
                     </quafzi_customergridordercount_adminhtml_block_html_before>
                 </observers>
-            </adminhtml_block_html_before>
+            </core_layout_block_create_after>
             <eav_collection_abstract_load_before>
                 <observers>
                     <quafzi_customergridordercount_change_collection>


### PR DESCRIPTION
With event core_layout_block_create_after the number of orders appears also in csv export. Tested on Magento Magento Version 1.9.0.1.
